### PR TITLE
feat: add distance sorting with vercel geolocation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "@trpc/server": "^11.0.0",
         "@types/cheerio": "^1.0.0",
         "@vercel/analytics": "^1.5.0",
+        "@vercel/functions": "^2.2.12",
         "cheerio": "^1.1.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -358,6 +359,8 @@
 
     "@types/json5": ["@types/json5@0.0.29", "", {}, "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="],
 
+    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
+
     "@types/node": ["@types/node@20.19.9", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw=="],
 
     "@types/react": ["@types/react@19.1.9", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA=="],
@@ -423,6 +426,10 @@
     "@unrs/resolver-binding-win32-x64-msvc": ["@unrs/resolver-binding-win32-x64-msvc@1.11.1", "", { "os": "win32", "cpu": "x64" }, "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g=="],
 
     "@vercel/analytics": ["@vercel/analytics@1.5.0", "", { "peerDependencies": { "@remix-run/react": "^2", "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@remix-run/react", "@sveltejs/kit", "next", "react", "svelte", "vue", "vue-router"] }, "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g=="],
+
+    "@vercel/functions": ["@vercel/functions@2.2.12", "", { "dependencies": { "@vercel/oidc": "2.0.1" }, "peerDependencies": { "@aws-sdk/credential-provider-web-identity": "*" }, "optionalPeers": ["@aws-sdk/credential-provider-web-identity"] }, "sha512-WGGqro/Rg00Epj+t2l6lr68q6ZkFt5+Q4F4Ok8sJbYrpu5pniDay09ihJqUoz81NI9PIfIahGEjaKpucUhEIrg=="],
+
+    "@vercel/oidc": ["@vercel/oidc@2.0.1", "", { "dependencies": { "@types/ms": "2.1.0", "ms": "2.1.3" } }, "sha512-p/rFk8vz+AggU0bHXjwtRUyXNxboLvfCjwN0KH5xhBJ5wGS+n/psLJP1c69QPdWIZM4aVVIrTqdjUuDwuJGYzQ=="],
 
     "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@trpc/server": "^11.0.0",
     "@types/cheerio": "^1.0.0",
     "@vercel/analytics": "^1.5.0",
+    "@vercel/functions": "^2.2.12",
     "cheerio": "^1.1.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/app/api/trpc/[trpc]/route.ts
+++ b/src/app/api/trpc/[trpc]/route.ts
@@ -12,6 +12,7 @@ import { createTRPCContext } from "~/server/api/trpc";
 const createContext = async (req: NextRequest) => {
   return createTRPCContext({
     headers: req.headers,
+    req,
   });
 };
 

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -5,6 +5,7 @@ import {
   ArrowUpDown,
   Calendar,
   Filter,
+  MapPin,
   Search,
 } from "lucide-react";
 import { useQueryState } from "nuqs";
@@ -55,6 +56,8 @@ function SearchPageContent() {
       case "year-desc":
       case "year-asc":
         return ArrowUpDown;
+      case "distance":
+        return MapPin;
       default:
         return ArrowUpDown;
     }
@@ -110,6 +113,10 @@ function SearchPageContent() {
   } = api.vehicles.search.useQuery(
     {
       query: debouncedQuery,
+      makes: filters.makes?.length ? filters.makes : undefined,
+      colors: filters.colors?.length ? filters.colors : undefined,
+      states: filters.states?.length ? filters.states : undefined,
+      yearRange: hasUserChangedRange ? debouncedYearRange : undefined,
     },
     {
       enabled: debouncedQuery.length > 0,
@@ -469,6 +476,10 @@ function SearchPageContent() {
           return sorted.sort((a, b) => b.year - a.year);
         case "year-asc":
           return sorted.sort((a, b) => a.year - b.year);
+        case "distance":
+          return sorted.sort(
+            (a, b) => a.location.distance - b.location.distance,
+          );
         default:
           return sorted;
       }
@@ -589,6 +600,9 @@ function SearchPageContent() {
                           </SelectItem>
                           <SelectItem value="year-asc">
                             Year (Low to High)
+                          </SelectItem>
+                          <SelectItem value="distance">
+                            Distance (Nearest)
                           </SelectItem>
                         </SelectContent>
                       </Select>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -81,7 +81,7 @@ export interface SearchFilters {
   dateRange?: [Date, Date];
   maxDistance?: number;
   userLocation?: [number, number];
-  sortBy?: "distance" | "date" | "year" | "make" | "location";
+  sortBy?: "newest" | "oldest" | "year-desc" | "year-asc" | "distance";
   sortOrder?: "asc" | "desc";
 }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,33 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
+}
+
+/**
+ * Calculate distance between two coordinates using Haversine formula
+ * @param lat1 Latitude of first point
+ * @param lng1 Longitude of first point
+ * @param lat2 Latitude of second point
+ * @param lng2 Longitude of second point
+ * @returns Distance in miles
+ */
+export function calculateDistance(
+  lat1: number,
+  lng1: number,
+  lat2: number,
+  lng2: number,
+): number {
+  const R = 3959; // Earth's radius in miles
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLng = ((lng2 - lng1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos((lat1 * Math.PI) / 180) *
+      Math.cos((lat2 * Math.PI) / 180) *
+      Math.sin(dLng / 2) *
+      Math.sin(dLng / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return R * c;
 }

--- a/src/server/api/routers/locations.ts
+++ b/src/server/api/routers/locations.ts
@@ -151,28 +151,6 @@ function getMockLocations(): Location[] {
   ];
 }
 
-/**
- * Calculate distance between two coordinates using Haversine formula
- */
-function calculateDistance(
-  lat1: number,
-  lng1: number,
-  lat2: number,
-  lng2: number,
-): number {
-  const R = 3959; // Earth's radius in miles
-  const dLat = ((lat2 - lat1) * Math.PI) / 180;
-  const dLng = ((lng2 - lng1) * Math.PI) / 180;
-  const a =
-    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-    Math.cos((lat1 * Math.PI) / 180) *
-      Math.cos((lat2 * Math.PI) / 180) *
-      Math.sin(dLng / 2) *
-      Math.sin(dLng / 2);
-  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-  return R * c;
-}
-
 export const locationsRouter = createTRPCRouter({
   /**
    * Get all LKQ locations
@@ -196,34 +174,6 @@ export const locationsRouter = createTRPCRouter({
       return allLocations.filter((location) =>
         input.states.includes(location.stateAbbr),
       );
-    }),
-
-  /**
-   * Get locations within a distance from user location
-   */
-  getByDistance: publicProcedure
-    .input(
-      z.object({
-        userLat: z.number(),
-        userLng: z.number(),
-        maxDistance: z.number(),
-      }),
-    )
-    .query(async ({ input }): Promise<Location[]> => {
-      const allLocations = await fetchLocationsFromLKQ();
-
-      return allLocations
-        .map((location) => ({
-          ...location,
-          distance: calculateDistance(
-            input.userLat,
-            input.userLng,
-            location.lat,
-            location.lng,
-          ),
-        }))
-        .filter((location) => location.distance <= input.maxDistance)
-        .sort((a, b) => a.distance - b.distance);
     }),
 
   /**

--- a/src/server/api/trpc.ts
+++ b/src/server/api/trpc.ts
@@ -22,7 +22,10 @@ import { ZodError } from "zod";
  *
  * @see https://trpc.io/docs/server/context
  */
-export const createTRPCContext = async (opts: { headers: Headers }) => {
+export const createTRPCContext = async (opts: {
+  headers: Headers;
+  req?: Request;
+}) => {
   return {
     ...opts,
   };


### PR DESCRIPTION
- Add @vercel/functions package for server-side IP geolocation
- Implement distance sorting option with MapPin icon
- Always include distance data for instant client-side distance sorting
- Solve extra API request issue by calculating distances for all vehicles
- Add graceful geolocation fallback for local development vs production
- Refactor calculateDistance function to shared utils, eliminate duplication
- Update tRPC context to include request object for geolocation access
- Enhance filtering with client-side state filtering support
- Remove unused getByDistance procedure from locations router